### PR TITLE
Added keyword argument to resolve an error

### DIFF
--- a/Section 1- Python Crash Course/5- Seaborn.ipynb
+++ b/Section 1- Python Crash Course/5- Seaborn.ipynb
@@ -532,7 +532,7 @@
    "source": [
     "## Count plot\n",
     "\n",
-    "sns.countplot('sex',data=df)"
+    "sns.countplot(x='sex',data=df)"
    ]
   },
   {


### PR DESCRIPTION
When I tried sns.countplot('species', data=df) on the iris dataset, I got the following error:
TypeError                                 Traceback (most recent call last)
<ipython-input-16-47d5b1af6791> in <cell line: 1>()
----> 1 sns.countplot('species', data=df)

TypeError: countplot() got multiple values for argument 'data'